### PR TITLE
Fix IndexError after deleting a task with dependencies

### DIFF
--- a/src/procrastitask/procrastitask_app.py
+++ b/src/procrastitask/procrastitask_app.py
@@ -190,11 +190,20 @@ class App:
         return os.path.isfile(self.get_config_path())
 
     def delete_task(self, task_title):
-        # print(f"Deleting title {task_title} from collection {self.all_tasks}")
         len_before = len(self.all_tasks)
+        specified_task = [task for task in self.all_tasks if task.title == task_title]
+        if not specified_task:
+            raise ValueError(f"I couldn't find the task with title: {task_title}")
+        elif len(specified_task) > 1:
+            raise ValueError(f"I found more than one task with title: {task_title}: {specified_task}")
+        else:
+            specified_task = specified_task[0]
         self.all_tasks = [task for task in self.all_tasks if task.title != task_title]
         if len_before == len(self.all_tasks):
             raise ValueError(f"I couldn't find the task with title: {task_title}")
+        # Remove the deleted task's identifier from other tasks' dependent_on lists
+        for task in self.all_tasks:
+            task.dependent_on = [dep for dep in task.dependent_on if dep != specified_task.identifier]
 
     def delete_task_by_idx(self, task_idx: int):
         selected_task = self.cached_listed_tasks.get(int(task_idx))

--- a/src/procrastitask/task.py
+++ b/src/procrastitask/task.py
@@ -225,8 +225,11 @@ class Task:
     def dependent_tasks_complete(self, all_tasks: List["Task"]) -> bool:
         saw_incomplete = False
         for task_id in self.dependent_on:
-            found = [t for t in all_tasks if t.identifier == task_id][0]
-            if not found._is_complete:
+            found = [t for t in all_tasks if t.identifier == task_id]
+            if not found:
+                log.warning(f"Dependent task with id {task_id} not found.")
+                continue
+            if not found[0]._is_complete:
                 saw_incomplete = True
         return not saw_incomplete
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,22 @@
-
 import unittest
 from procrastitask.procrastitask_app import App
+from procrastitask.task import Task
 
 
 class TestApp(unittest.TestCase):
     def test_can_initialize_app(self):
         App()
+
+    def test_delete_task_by_idx_updates_dependent_on(self):
+        app = App()
+        task1 = Task("Task 1", "description", 1, 1, 1)
+        task2 = Task("Task 2", "description", 1, 1, 1, dependent_on=[task1.identifier])
+        task3 = Task("Task 3", "description", 1, 1, 1, dependent_on=[task1.identifier])
+        
+        app.all_tasks = [task1, task2, task3]
+        app.cached_listed_tasks = {0: task1, 1: task2, 2: task3}
+        
+        app.delete_task_by_idx(0)
+        
+        self.assertNotIn(task1.identifier, task2.dependent_on)
+        self.assertNotIn(task1.identifier, task3.dependent_on)


### PR DESCRIPTION
Fixes #2

Fix the IndexError when deleting a task that has another task dependent on it.

* Update `delete_task` method in `src/procrastitask/procrastitask_app.py` to remove the deleted task's identifier from other tasks' `dependent_on` lists.
* Update `delete_task_by_idx` method in `src/procrastitask/procrastitask_app.py` to call the updated `delete_task` method.
* Update `dependent_tasks_complete` method in `src/procrastitask/task.py` to handle the case where a dependent task has been deleted and log a warning if a dependent task is not found.
* Add a test case in `tests/test_app.py` to verify that the `delete_task_by_idx` method updates other tasks' `dependent_on` lists when a task is deleted.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhaenchen/procrastitask/pull/3?shareId=3f60e798-c436-478d-963f-1218e4e270cc).