### PR TITLE
Add task status field and related functionalities

### DIFF
--- a/src/procrastitask/task.py
+++ b/src/procrastitask/task.py
@@ -104,7 +104,7 @@ class Task:
         self._is_complete = result
         if result:
             self.status = TaskStatus.COMPLETE
-        else if self.status == TaskStatus.COMPLETE:
+        elif self.status == TaskStatus.COMPLETE:
             self.status = TaskStatus.INCOMPLETE
         return self._is_complete
 
@@ -164,6 +164,7 @@ class Task:
         """
         if self.history:
             return max(self.history, key=lambda completion_rec: completion_rec.completed_at)
+        return None
 
     def create_and_launch_ical_event(self):
         cal = icalendar.Calendar()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,6 @@
 import unittest
 from procrastitask.procrastitask_app import App
-from procrastitask.task import Task
+from procrastitask.task import Task, TaskStatus
 
 
 class TestApp(unittest.TestCase):
@@ -20,3 +20,36 @@ class TestApp(unittest.TestCase):
         
         self.assertNotIn(task1.identifier, task2.dependent_on)
         self.assertNotIn(task1.identifier, task3.dependent_on)
+
+    def test_set_task_in_progress_via_command(self):
+        app = App()
+        task = Task("Task 1", "description", 1, 1, 1)
+        app.all_tasks = [task]
+        app.cached_listed_tasks = {0: task}
+        
+        app.display_home("q0")
+        
+        self.assertEqual(task.status, TaskStatus.IN_PROGRESS)
+
+    def test_set_task_incomplete_via_command(self):
+        app = App()
+        task = Task("Task 1", "description", 1, 1, 1)
+        task.set_in_progress()
+        app.all_tasks = [task]
+        app.cached_listed_tasks = {0: task}
+        
+        app.display_home("dq0")
+        
+        self.assertEqual(task.status, TaskStatus.INCOMPLETE)
+
+    def test_view_in_progress_tasks(self):
+        app = App()
+        task1 = Task("Task 1", "description", 1, 1, 1)
+        task2 = Task("Task 2", "description", 1, 1, 1)
+        task2.set_in_progress()
+        app.all_tasks = [task1, task2]
+        
+        in_progress_tasks = app.list_in_progress_tasks()
+        
+        self.assertIn(task2, in_progress_tasks)
+        self.assertNotIn(task1, in_progress_tasks)


### PR DESCRIPTION
Add status field to tasks and implement related functionalities.

* Add `status` attribute to `Task` class in `src/procrastitask/task.py` with possible values: INCOMPLETE, IN_PROGRESS, COMPLETE.
* Update `is_complete` property to auto-update `status` based on task logic.
* Add methods to set a task to IN_PROGRESS and move it back to INCOMPLETE.
* Update `from_dict` and `to_dict` methods to handle `status` attribute.

* Update `src/procrastitask/procrastitask_app.py` to allow users to set a task to IN_PROGRESS via `q{INDEX}`, move it back to INCOMPLETE via `dq{INDEX}`, and view IN_PROGRESS tasks via `q`.

* Add test cases in `tests/test_task.py` for setting task status to IN_PROGRESS and moving it back to INCOMPLETE.
* Add test cases in `tests/test_app.py` for new functionalities: `q{INDEX}`, `dq{INDEX}`, and viewing IN_PROGRESS tasks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhaenchen/procrastitask/pull/5?shareId=a77e7a99-be9d-4e2b-90a6-5cf649c584d4).