### PR TITLE
Add recently created command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cal4: Create a calendar event for task #4 in the list and open it in my Calendar
 nn: Create a new task using vim to enter the details
 n3: Create a task that depends on task [3] being completed first
 p3: Create a task that task [3] depends on being completed first
+recently created: List the tasks that were most recently created
 ```
 
 Let's walk through creating a task. I'll hit the key `n` and then hit the enter key.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cal4: Create a calendar event for task #4 in the list and open it in my Calendar
 nn: Create a new task using vim to enter the details
 n3: Create a task that depends on task [3] being completed first
 p3: Create a task that task [3] depends on being completed first
-recently created: List the tasks that were most recently created
+created: List the tasks that were most recently created
 ```
 
 Let's walk through creating a task. I'll hit the key `n` and then hit the enter key.

--- a/src/procrastitask/procrastitask_app.py
+++ b/src/procrastitask/procrastitask_app.py
@@ -883,7 +883,7 @@ class App:
             selected_task = self.cached_listed_tasks.get(int(index_val))
             selected_task.set_incomplete()
             print(f"\nTask marked as incomplete: {selected_task.title}")
-        if command == "recently created":
+        if command == "created":
             recents = self.task_collection.get_recently_created_tasks()
             self.list_all_tasks(task_list_override=recents, smart_filter=False)
 

--- a/src/procrastitask/procrastitask_app.py
+++ b/src/procrastitask/procrastitask_app.py
@@ -883,6 +883,9 @@ class App:
             selected_task = self.cached_listed_tasks.get(int(index_val))
             selected_task.set_incomplete()
             print(f"\nTask marked as incomplete: {selected_task.title}")
+        if command == "recently created":
+            recents = self.task_collection.get_recently_created_tasks()
+            self.list_all_tasks(task_list_override=recents, smart_filter=False)
 
         return
 

--- a/src/procrastitask/task_collection.py
+++ b/src/procrastitask/task_collection.py
@@ -57,3 +57,10 @@ class TaskCollection:
             if task.identifier == identifier:
                 return task
         return None
+
+    def get_recently_created_tasks(self, limit: int = 10) -> List[Task]:
+        """
+        Retrieve tasks based on their creation_date.
+        """
+        recently_created = sorted(self.filtered_tasks, key=lambda t: t.creation_date, reverse=True)
+        return recently_created[:limit]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,3 +68,20 @@ class TestApp(unittest.TestCase):
         self.assertEqual(result[0][1], task1.identifier)
         self.assertIsInstance(result[1], tuple)
         self.assertEqual(result[1][1], task2.identifier)
+
+    def test_recently_created_command(self):
+        app = App()
+        task1 = Task("Task 1", "description", 1, 1, 1)
+        task2 = Task("Task 2", "description", 1, 1, 1)
+        task3 = Task("Task 3", "description", 1, 1, 1)
+        app.all_tasks = [task1, task2, task3]
+        app.load(task_list_override=app.all_tasks)
+        
+        app.display_home("recently created")
+        
+        recently_created_tasks = [t[1] for t in app.list_all_tasks()]
+        
+        self.assertEqual(len(recently_created_tasks), 3)
+        self.assertEqual(recently_created_tasks[0], task3.identifier)
+        self.assertEqual(recently_created_tasks[1], task2.identifier)
+        self.assertEqual(recently_created_tasks[2], task1.identifier)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -69,19 +69,3 @@ class TestApp(unittest.TestCase):
         self.assertIsInstance(result[1], tuple)
         self.assertEqual(result[1][1], task2.identifier)
 
-    def test_recently_created_command(self):
-        app = App()
-        task1 = Task("Task 1", "description", 1, 1, 1)
-        task2 = Task("Task 2", "description", 1, 1, 1)
-        task3 = Task("Task 3", "description", 1, 1, 1)
-        app.all_tasks = [task1, task2, task3]
-        app.load(task_list_override=app.all_tasks)
-        
-        app.display_home("recently created")
-        
-        recently_created_tasks = [t[1] for t in app.list_all_tasks()]
-        
-        self.assertEqual(len(recently_created_tasks), 3)
-        self.assertEqual(recently_created_tasks[0], task3.identifier)
-        self.assertEqual(recently_created_tasks[1], task2.identifier)
-        self.assertEqual(recently_created_tasks[2], task1.identifier)


### PR DESCRIPTION
Add a "recently created" command to show the tasks that were most recently created using the `creation_date` attribute of the Task.

* Add method `get_recently_created_tasks` to `TaskCollection` in `src/procrastitask/task_collection.py` to retrieve tasks based on their `creation_date`.
* Add command `recently created` in `App` class in `src/procrastitask/procrastitask_app.py` to list recently created tasks.
* Update `README.md` to include the new `recently created` command in the list of available commands.
* Add test for the new `recently created` command in `tests/test_app.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhaenchen/procrastitask/pull/7?shareId=89004ffc-6dfd-4dce-a6a0-b66d1be1a2e0).