### PR TITLE
Add support for location names in LocationDynamic

### DIFF
--- a/src/procrastitask/dynamics/location_dynamic.py
+++ b/src/procrastitask/dynamics/location_dynamic.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from .base_dynamic import BaseDynamic
-from ..location import get_location
+from ..location import get_location, get_location_from_name
 from geopy.distance import geodesic
 
 
@@ -50,6 +50,9 @@ class LocationDynamic(BaseDynamic):
             if location is None:
                 raise RuntimeError("Unable to get current location")
             latitude, longitude = map(float, location.split(","))
+            radius = float(parts[-1])
+        elif parts[0] in get_location_from_name(parts[0]):
+            latitude, longitude = get_location_from_name(parts[0])
             radius = float(parts[-1])
         else:
             latitude, longitude, radius = map(float, parts)

--- a/src/procrastitask/dynamics/location_dynamic.py
+++ b/src/procrastitask/dynamics/location_dynamic.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from .base_dynamic import BaseDynamic
 from ..location import get_location, get_location_from_name
 from geopy.distance import geodesic
+from logging import getLogger
 
+logger = getLogger(__name__)
 
 @dataclass
 class LocationDynamic(BaseDynamic):
@@ -36,28 +38,35 @@ class LocationDynamic(BaseDynamic):
 
     @staticmethod
     def from_text(text: str) -> "LocationDynamic":
-        parts = None
-        for prefix in LocationDynamic.prefixes:
-            prefix = BaseDynamic.get_cleaned_prefix(prefix)
-            if prefix in text:
-                parts = text.split(prefix)
-        if parts is None:
-            raise ValueError(f"Invalid text repr: {text}")
+        try:
+            parts = None
+            for prefix in LocationDynamic.prefixes:
+                prefix = BaseDynamic.get_cleaned_prefix(prefix)
+                if prefix in text:
+                    parts = text.split(prefix)
+            if parts is None:
+                raise ValueError(f"Invalid text repr: {text}")
 
-        parts = parts[-1:][0].split("/")
-        if "current" in parts[:2]:
-            location = get_location()
-            if location is None:
-                raise RuntimeError("Unable to get current location")
-            latitude, longitude = map(float, location.split(","))
-            radius = float(parts[-1])
-        elif parts[0] in get_location_from_name(parts[0]):
-            latitude, longitude = get_location_from_name(parts[0])
-            radius = float(parts[-1])
-        else:
-            latitude, longitude, radius = map(float, parts)
+            parts = parts[-1:][0].split("/")
+            if "current" in parts[:2]:
+                location = get_location()
+                if location is None:
+                    raise RuntimeError("Unable to get current location")
+                latitude, longitude = map(float, location.split(","))
+                radius = float(parts[-1])
+            elif get_location_from_name(parts[0]):
+                latitude, longitude = get_location_from_name(parts[0])
+                radius = float(parts[-1])
+            else:
+                latitude, longitude, radius = map(float, parts)
 
-        return LocationDynamic(latitude=latitude, longitude=longitude, radius=radius)
+            return LocationDynamic(latitude=latitude, longitude=longitude, radius=radius)
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error while parsing location dynamic from text: {e}")
+            raise
+        return None
 
     def to_text(self):
         return f"dynamic-location/{self.latitude}/{self.longitude}/{self.radius}"

--- a/src/procrastitask/location.py
+++ b/src/procrastitask/location.py
@@ -46,10 +46,10 @@ def get_location(nocache=False):
 
 def get_location_from_name(name):
     location_map = {
-        "houston": (29.7601, 95.3701),
-        "ingram": (30.0774, 99.2403),
-        "nyc": (40.7128, 74.0060),
-        "timbergrove": (29.7929,−95.4209),
+        "houston": (29.7601, -95.3701),
+        "ingram": (30.0774, -99.2403),
+        "nyc": (40.7128, -74.0060),
+        "timbergrove": (29.7929,-95.4209),
         "tcjester": (29.824459,-95.453439)
         # Add more mappings as needed
     }

--- a/src/procrastitask/location.py
+++ b/src/procrastitask/location.py
@@ -43,3 +43,14 @@ def get_location(nocache=False):
         log.debug(f"Error getting location from IP: {e}")
 
     return None
+
+def get_location_from_name(name):
+    location_map = {
+        "houston": (29.7601, 95.3701),
+        "ingram": (30.0774, 99.2403),
+        "nyc": (40.7128, 74.0060),
+        "timbergrove": (29.7929,−95.4209),
+        "tcjester": (29.824459,-95.453439)
+        # Add more mappings as needed
+    }
+    return location_map.get(name)

--- a/tests/dynamics/test_location_dynamic.py
+++ b/tests/dynamics/test_location_dynamic.py
@@ -1,0 +1,56 @@
+import unittest
+from datetime import datetime
+from procrastitask.dynamics.location_dynamic import LocationDynamic
+from procrastitask.task import Task
+
+class TestLocationDynamic(unittest.TestCase):
+
+    def setUp(self):
+        self.base_stress = 100
+        self.latitude = 88.222
+        self.longitude = -19.222
+        self.radius = 1000
+        self.dynamic = LocationDynamic(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            radius=self.radius
+        )
+        self.base_task = Task(title="Test Task", description="Test Description", difficulty=1, duration=1, stress=self.base_stress)
+
+    def test_apply_within_radius(self):
+        with unittest.mock.patch('procrastitask.location.get_location', return_value="88.222,-19.222"):
+            new_stress = self.dynamic.apply(datetime.now(), self.base_stress, self.base_task)
+            expected_stress = self.base_stress * 2
+            self.assertEqual(new_stress, expected_stress)
+
+    def test_apply_outside_radius(self):
+        with unittest.mock.patch('procrastitask.location.get_location', return_value="0.0,0.0"):
+            new_stress = self.dynamic.apply(datetime.now(), self.base_stress, self.base_task)
+            self.assertEqual(new_stress, self.base_stress)
+
+    def test_apply_null_location(self):
+        with unittest.mock.patch('procrastitask.location.get_location', return_value=None):
+            new_stress = self.dynamic.apply(datetime.now(), self.base_stress, self.base_task)
+            self.assertEqual(new_stress, self.base_stress)
+
+    def test_from_text_with_coordinates(self):
+        text = "location/88.222/-19.222/1000"
+        dynamic = LocationDynamic.from_text(text)
+        self.assertEqual(dynamic.latitude, 88.222)
+        self.assertEqual(dynamic.longitude, -19.222)
+        self.assertEqual(dynamic.radius, 1000)
+
+    def test_from_text_with_name(self):
+        text = "location/houston/1000"
+        dynamic = LocationDynamic.from_text(text)
+        self.assertEqual(dynamic.latitude, 88.222)
+        self.assertEqual(dynamic.longitude, -19.222)
+        self.assertEqual(dynamic.radius, 1000)
+
+    def test_to_text(self):
+        text = self.dynamic.to_text()
+        expected_text = f"dynamic-location/{self.latitude}/{self.longitude}/{self.radius}"
+        self.assertEqual(text, expected_text)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add support for specifying a short form name that refers to a location in the `LocationDynamic` class.

* Add `get_location_from_name` function in `src/procrastitask/location.py` to map a name to a lat-long tuple.
* Update `from_text` method in `src/procrastitask/dynamics/location_dynamic.py` to support short form names using the `get_location_from_name` function.
* Add unit tests in `tests/dynamics/test_location_dynamic.py` to test the new functionality of the `LocationDynamic` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhaenchen/procrastitask/pull/9?shareId=fee6d9af-c433-42cd-be1f-e2ba6f5b6e5b).