### PR TITLE
Fix stress rendering to have at most one digit after the decimal

### DIFF
--- a/src/procrastitask/task.py
+++ b/src/procrastitask/task.py
@@ -60,7 +60,7 @@ class Task:
         floated = float(val)
         if floated.is_integer():
             return int(floated)
-        return floated
+        return round(floated, 1)
 
     @property
     def is_complete(self):
@@ -136,12 +136,12 @@ class Task:
         log.debug(f"Evaluating rendered stress for task {self.title}")
         base_stress = self.stress
         if not self.stress_dynamic:
-            return base_stress
+            return round(base_stress, 1)
         base_stress_date = self.last_refreshed
         if self.periodicity:
             cron = croniter.croniter(self.periodicity, datetime.now())
             base_stress_date = cron.get_prev(datetime)
-        return self.stress_dynamic.apply(base_stress_date, self.stress, self)
+        return round(self.stress_dynamic.apply(base_stress_date, self.stress, self), 1)
 
     def update_last_refreshed(self):
         self.last_refreshed = datetime.now()


### PR DESCRIPTION
Update the stress value rendering in task headlines to have at most one digit after the decimal.

* Modify the `_format_num_as_int_if_possible` method to round float values to one decimal place.
* Update the `get_rendered_stress` method to return the stress value rounded to one decimal place.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhaenchen/procrastitask/pull/10?shareId=855d8818-cc88-4286-85be-5f35b328a250).